### PR TITLE
Module::Info -> Module::Extract::Use

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -68,7 +68,7 @@ my %WriteMakefile = (
 
 	'PREREQ_PM'	    => {
 		'Module::CoreList'       => '0',
-		'Module::Info'           => '0',
+		'Module::Extract::Use'   => '0',
 		},
 
 	'META_MERGE' => {

--- a/lib/Test/Prereq.pm
+++ b/lib/Test/Prereq.pm
@@ -122,11 +122,13 @@ use Carp qw(carp);
 use ExtUtils::MakeMaker;
 use File::Find;
 use Module::CoreList;
-use Module::Info;
+use Module::Extract::Use;
 use Test::Builder;
 use Test::More;
 
 my $Test = Test::Builder->new;
+
+my $Extractor = Module::Extract::Use->new;
 
 my $Namespace = '';
 
@@ -452,10 +454,7 @@ sub _get_from_file
 	{
 	my( $class, $file ) = @_;
 
-	my $module  = Module::Info->new_from_file( $file );
-	$module->die_on_compilation_error(1);
-
-	my @used    = eval{ $module->modules_used };
+	my @used = $Extractor->get_modules( $file );
 
 	my @modules =
 		sort

--- a/t/get_from_file.t
+++ b/t/get_from_file.t
@@ -2,7 +2,7 @@ use Test::More 0.95;
 
 use Test::Prereq;
 
-my @prereq_files = qw( Module::Info );
+my @prereq_files = qw( Module::Extract::Use );
 
 my @tests = (
 	[ 't/pod.t',            [ ]                 ],

--- a/t/get_loaded_modules.t
+++ b/t/get_loaded_modules.t
@@ -7,7 +7,7 @@ subtest 'modules' => sub {
 
 	my $keys = [ grep ! /^CPANPLUS/, sort keys %$modules ];
 
-	my @expected = qw( Module::Info Test::Prereq Test::Prereq::Build );
+	my @expected = qw( Module::Extract::Use Test::Prereq Test::Prereq::Build );
 	unshift @expected, qw(Module::Build) if $] =~ m/\A5.008/ or $] > 5.020002;
 
 	@expected = sort @expected;


### PR DESCRIPTION
This is first part of https://github.com/briandfoy/test-prereq/issues/10 to use Modeul::Extract::Use instead of Module::Info